### PR TITLE
config(editorconfig): standardize header format and add license notation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,18 +1,10 @@
-## @(#) : editorconfig common template for atsushifx
-##
-## EditorConfig is awesome: https://EditorConfig.org
+# src: shared/configs/secretlint.config.base.yaml
+# @(#) : secretlint base configuration
 #
-# @version  1.2.1
-# @date     2025-04-25
-# @author   atsushifx <https://github.com/atsushifx/>
-# @license  MIT
+# Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 #
-# @description<<
-#
-# Common editor settings for general programming and documentation files.
-# Applies consistent indentation and line-ending rules.
-#
-#<<
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
 
 root = true
 


### PR DESCRIPTION
## ✨ Overview

Standardized the .editorconfig header format to align with project conventions and added proper MIT license attribution. This change simplifies the header comments by removing redundant metadata and replacing the verbose description with a concise source reference and license notation, improving consistency across configuration files.

---

## 🔧 Changes

List the key changes included in this PR:

- [x] Updated .editorconfig header format
- [x] Added MIT license and copyright notation
- [x] Removed redundant version, date, author metadata from header
- [x] Simplified description with source reference format

### Configuration Files

- `.editorconfig`: Standardized header format (5 insertions, 13 deletions)

---

## 📂 Related Issues

> Related [#7](https://github.com/atsushifx/.github/issues/7)

---

## ✅ Checklist

Please confirm the following before requesting review:

- [ ] Lint checks pass (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

This is a configuration-only change that does not affect functionality. The .editorconfig rules remain unchanged - only the header format has been updated to match the standardized format used across other configuration files in this repository.
