### PR TITLE
ci(workflow): rename secrets scan workflow to common naming convention

### DIFF
--- a/.github/workflows/ci-common-scan-secrets.yml
+++ b/.github/workflows/ci-common-scan-secrets.yml
@@ -6,7 +6,7 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
-name: Scan secrets for CI
+name: Common CI Scan Secrets
 permissions:
   contents: read
 


### PR DESCRIPTION
## ✨ Overview

This PR standardizes the secrets scanning workflow naming to follow the common workflow naming convention established in this repository. The workflow file is renamed from `ci-secrets-scan.yml` to `ci-common-scan-secrets.yml`, and the workflow display name is updated to "Common CI Scan Secrets" for better consistency with other common CI workflows.

This change improves discoverability and maintainability by aligning with the repository's workflow organization strategy, where common workflows share a consistent naming pattern (`ci-common-*`).

---

## 🔧 Changes

### Core Changes

- [Config] `.github/workflows/ci-secrets-scan.yml` → `.github/workflows/ci-common-scan-secrets.yml` (renamed)
  - Updated workflow `name` field from "Scan secrets for CI" to "Common CI Scan Secrets"
  - File structure and functionality remain unchanged
  - Only 1 insertion and 1 deletion (name change only)

**File Changes Summary:**
- Total files changed: 1
- Configuration files: 1 (workflow rename)

---

## 📂 Related Issues

Ref #14

---

## ✅ Checklist

Please confirm the following before requesting review:

- [x] Lint checks pass (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

This is a low-risk change that only affects workflow naming and display. The workflow logic, triggers, and functionality remain completely unchanged. No breaking changes are introduced.

The new naming convention (`ci-common-*`) helps distinguish shared/common workflows from project-specific CI workflows, improving the overall organization of the `.github/workflows/` directory.
