### PR TITLE
ci(workflow): enable ghalint config file usage

### DIFF
--- a/.github/workflows/ci-common-lint-ghalint.yml
+++ b/.github/workflows/ci-common-lint-ghalint.yml
@@ -101,8 +101,7 @@ jobs:
           mkdir -p .github/report
 
           set +e
-          # ghalint run --log-color always -c ${{ inputs.config-file }} 2>&1 | tee .github/report/report.log
-          ghalint run --log-color always 2>&1 | tee .github/report/report.log
+          ghalint run --log-color always -c ${{ inputs.config-file }} 2>&1 | tee .github/report/report.log
           ghalint_status=${PIPESTATUS[0]}
           set -e
 


### PR DESCRIPTION
## ✨ Overview

This PR restores the configuration file argument for ghalint execution in the reusable workflow, ensuring consistent linting behavior across all repositories. The change uncomments the `-c ${{ inputs.config-file }}` parameter that was previously disabled, allowing ghalint to use centralized configuration from the `.github` repository instead of relying on default settings.

This unifies the execution policy and eliminates inconsistency between intended configuration-driven behavior and actual runtime execution.

---

## 🔧 Changes

List the key changes included in this PR:

- [x] Updated workflow to use config file parameter
- [x] Removed commented-out configuration line
- [x] Removed legacy execution without config file
- [x] Refactored for consistency with other lint workflows

---

## 📂 Related Issues

Related #14

---

## ✅ Checklist

Please confirm the following before requesting review:

- [ ] Lint checks pass (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

### Changed Files

**Workflow Configuration (1 file):**
- `.github/workflows/ci-common-lint-ghalint.yml` - Enabled config file parameter for ghalint execution

### Technical Details

The change modifies line 104 of the ghalint workflow to use:
```bash
ghalint run --log-color always -c ${{ inputs.config-file }} 2>&1 | tee .github/report/report.log
```

This ensures that when other repositories call this reusable workflow, ghalint will properly load the shared configuration file, maintaining consistency with the project's "Configuration as Truth" principle.
