### PR TITLE
ci(workflows): pin reusable workflow references to r1.0.0 tag

### DIFF
--- a/.github/workflows/ci-scan-all.yml
+++ b/.github/workflows/ci-scan-all.yml
@@ -6,7 +6,7 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
-name: CI Scan All
+name: "CI Scan All"
 
 # Minimal permissions following security best practices
 permissions:
@@ -36,10 +36,10 @@ jobs:
     name: Ghalint
     permissions:
       contents: read
-    uses: atsushifx/.github/.github/workflows/ci-common-lint-ghalint.yml@main@r1.0.0
+    uses: atsushifx/.github/.github/workflows/ci-common-lint-ghalint.yml@r1.0.0
 
   scan-gitleaks:
     name: Gitleaks Secret Scan
     permissions:
       contents: read
-    uses: atsushifx/.github/.github/workflows/ci-common-scan-gitleaks.yml@main@r1.0.0
+    uses: atsushifx/.github/.github/workflows/ci-common-scan-gitleaks.yml@r1.0.0


### PR DESCRIPTION
## ✨ Overview

This PR corrects the reusable workflow references in `ci-scan-all.yml` to properly pin them to the `r1.0.0` release tag. The previous reference format `@main@r1.0.0` was invalid and has been corrected to `@r1.0.0`, ensuring workflows use the stable tagged version instead of the main branch. Additionally, the workflow name has been enclosed in quotes for consistency with other workflow files.

This change improves workflow stability by ensuring that CI runs use a fixed, tested version of the reusable workflows rather than potentially untested changes from the main branch.

---

## 🔧 Changes

List the key changes included in this PR:

- [x] Added/updated files or modules
  - Updated `.github/workflows/ci-scan-all.yml` to fix reusable workflow references
  - Changed workflow name format to use quoted string
- [ ] Removed deprecated logic or configs
- [ ] Refactored for clarity/performance
- [ ] Other (please describe below)

### Core Changes

- **Fixed reusable workflow references**: Changed `@main@r1.0.0` to `@r1.0.0` for both:
  - `ci-common-lint-ghalint.yml`
  - `ci-common-scan-gitleaks.yml`
- **Standardized workflow name**: Enclosed workflow name in quotes (`"CI Scan All"`)

---

## 📂 Related Issues

Related to #14

---

## ✅ Checklist

Please confirm the following before requesting review:

- [x] Lint checks pass (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

**Context**: This change is part of the task-14 branch which focuses on updating GitHub Actions workflows to use proper version pinning for reusable workflows. The `@main@r1.0.0` format was not a valid Git reference format - GitHub Actions expects either a branch name, tag name, or commit SHA after the `@` symbol.

**Impact**: This fix ensures that the CI workflows will run correctly and use the intended stable version (`r1.0.0`) of the reusable workflow definitions, improving reliability and reproducibility of CI runs.
