### PR TITLE
ci(workflows): update workflow reference to r1.0.0 tag

### DIFF
--- a/.github/workflows/ci-scan-all.yml
+++ b/.github/workflows/ci-scan-all.yml
@@ -6,7 +6,7 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
-name: CI Scan All
+name: "CI Scan All"
 
 # Minimal permissions following security best practices
 permissions:
@@ -36,10 +36,10 @@ jobs:
     name: Ghalint
     permissions:
       contents: read
-    uses: atsushifx/.github/.github/workflows/ci-common-lint-ghalint.yml@main@r1.0.0
+    uses: atsushifx/.github/.github/workflows/ci-common-lint-ghalint.yml@r1.0.0
 
   scan-gitleaks:
     name: Gitleaks Secret Scan
     permissions:
       contents: read
-    uses: atsushifx/.github/.github/workflows/ci-common-scan-gitleaks.yml@main@r1.0.0
+    uses: atsushifx/.github/.github/workflows/ci-common-scan-gitleaks.yml@r1.0.0


### PR DESCRIPTION
## ✨ Overview

This PR updates the reusable workflow references in `ci-scan-all.yml` to use the stable `r1.0.0` release tag instead of the previous `main@r1.0.0` format. This change ensures consistent workflow versioning across the CI/CD pipeline and follows GitHub Actions best practices for pinning reusable workflows to specific versions.

Additionally, the workflow name has been updated with proper quoting for consistency with other workflow files in the repository.

**Background**: The previous reference format `@main@r1.0.0` was corrected to simply `@r1.0.0`, which properly pins the workflow to the tagged release version. This ensures reproducible builds and prevents unexpected changes from the main branch affecting CI runs.

---

## 🔧 Changes

### CI/CD Configuration

- [x] Updated reusable workflow references from `@main@r1.0.0` to `@r1.0.0`
  - `ci-common-lint-ghalint.yml`: Fixed workflow reference
  - `ci-common-scan-gitleaks.yml`: Fixed workflow reference
- [x] Added quotes to workflow name for consistency
- [x] Improved workflow version pinning strategy

**Modified Files:**
- `.github/workflows/ci-scan-all.yml` (1 file)

---

## 📂 Related Issues


## ✅ Checklist

Please confirm the following before requesting review:

- [x] Lint checks pass (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

**Impact**: This change affects all CI runs that depend on `ci-scan-all.yml`. The workflow now references stable, tagged versions of reusable workflows instead of potentially unstable references.

**Testing**: Verify that all workflow jobs (actionlint, ghalint, gitleaks) continue to execute correctly with the updated references.
